### PR TITLE
try to fix the flicker when using pad w/o playback

### DIFF
--- a/audio_ctrl.c
+++ b/audio_ctrl.c
@@ -159,6 +159,7 @@ build_audio_ctrl(struct audio_ctrl *ctrl, const char *path, u_int mode,
 	ctrl->path = path;
 	ctrl->fd = fd;
 	ctrl->mode = mode;
+	ctrl->pad = is_pad_device(path);
 
 	if (is_pad_device(path)) {
 		ctrl->config.precision = 16;

--- a/audio_ctrl.c
+++ b/audio_ctrl.c
@@ -161,7 +161,7 @@ build_audio_ctrl(struct audio_ctrl *ctrl, const char *path, u_int mode,
 	ctrl->mode = mode;
 	ctrl->pad = is_pad_device(path);
 
-	if (is_pad_device(path)) {
+	if (ctrl->pad) {
 		ctrl->config.precision = 16;
 		ctrl->config.encoding = AUDIO_ENCODING_SLINEAR_LE;
 		ctrl->config.buffer_size = 65268;

--- a/audio_ctrl.h
+++ b/audio_ctrl.h
@@ -51,6 +51,7 @@ struct stream {
 };
 
 struct audio_ctrl {
+	char pad;					/* is a pad device */
 	int fd;                     /* file descriptor to the audio device */
 	u_int mode;                 /* record vs play */
 	struct audio_config config; /* the configuration of the audio device */

--- a/audiov.1
+++ b/audiov.1
@@ -1,4 +1,4 @@
-.\"     $NetBSD: audiov.1,v 1.0 2026/06/25 17:02:20 gummybuns Exp $
+.\"     $NetBSD: audiov.1,v 1.0 2026/07/21 13:15:00 gummybuns Exp $
 .\"
 .\" Copyright (c) 2021 The NetBSD Foundation, Inc.
 .\" All rights reserved.
@@ -214,17 +214,3 @@ as a physical audio device.
 was written by
 .An Zac Brown
 .Aq gummybuns@protonmail.com .
-.Sh Bugs
-.Pp
-When
-.Ar device
-is specified as a
-.Xr pad 4
-device
-and
-.Ar output-device
-is not included,
-.Nm
-will appear to flicker. I believe this is because the
-.Xr pad 4
-device is padded with zeros until the full dataset can be read.

--- a/draw.c
+++ b/draw.c
@@ -28,9 +28,11 @@
  */
 #include <curses.h>
 #include <err.h>
+#include <errno.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "audio_ctrl.h"
 #include "draw.h"
@@ -52,6 +54,7 @@ struct thread_context {
 
 static void *do_record(void *);
 static void do_record_cleanup(void *);
+static int msleep(u_int);
 
 /*
  * Print details about the audio controller
@@ -287,6 +290,22 @@ calculate_coords(struct coords *coords, struct draw_config cfg, int bi, int xi,
 	coords->starty = starty;
 }
 
+static int
+msleep(u_int ms)
+{
+	int res;
+	struct timespec ts;
+
+	ts.tv_sec = ms / 1000;
+	ts.tv_nsec = (ms % 1000) * 1000000L;
+
+	do {
+		res = nanosleep(&ts, &ts);
+	} while (res && errno == EINTR);
+
+	return res;
+}
+
 /*
  * Displays a screen to record audio and display the data in the frequency
  * spectrum.
@@ -381,6 +400,16 @@ draw_frequency(struct audio_ctrl *rctrl, struct audio_ctrl *pctrl,
 
 			if (pctrl != NULL) {
 				if ((res = stream(pctrl, dd)) != 0) {
+					goto finish;
+				}
+			} else if (rctrl->pad) {
+				/*
+				 * When using pad without playback there is a flicker. Sleep
+				 * the same amount of time as playback should take.
+				 * There is probably a better way than sleeping...
+				 */
+				if (msleep(rctrl->stream.ms) != 0) {
+					res = E_STREAM_PAD_DELAY;
 					goto finish;
 				}
 			}

--- a/error_codes.h
+++ b/error_codes.h
@@ -25,6 +25,7 @@
 #define E_FREQ_UNSUPPORTED_ENCODING 2501
 
 #define E_STREAM_IO_ERROR 3000
+#define E_STREAM_PAD_DELAY 3001
 
 static inline const char *get_error_msg(int code);
 
@@ -66,6 +67,8 @@ get_error_msg(int code)
 		return "Unsupported encoding";
 	case E_STREAM_IO_ERROR:
 		return "Streaming I/O error";
+	case E_STREAM_PAD_DELAY:
+		return "Streaming pad device failed to sleep";
 	case E_UNHANDLED:
 	default:
 		return "Unhandled Error";

--- a/main.c
+++ b/main.c
@@ -275,8 +275,7 @@ main(int argc, char *argv[])
 	}
 
 	/* pad devices cannot have their configurations changed */
-	if (!is_pad_device(rctrl.path) &&
-	    (res = update_audio_ctrl(&rctrl, audio_config)) != 0) {
+	if (!rctrl.pad && (res = update_audio_ctrl(&rctrl, audio_config)) != 0) {
 		goto handle_error;
 	}
 	set_stream_rate(&rctrl, record_rate);
@@ -293,7 +292,7 @@ main(int argc, char *argv[])
 		}
 
 		/* the buffer sizes must match or you get a clicky sound */
-		if (is_pad_device(rctrl.path)) {
+		if (rctrl.pad) {
 			rctrl.config.buffer_size = pctrl->config.buffer_size;
 		}
 


### PR DESCRIPTION
- instead of playback try to sleep the same amount of time
- add a pad flag to the ctrl to know if the device is pad or not
- add method to sleep specified milliseconds
- handle sleep errors